### PR TITLE
Expose caddy via http only

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -2,7 +2,9 @@
     email samuel@oechsler.it
 }
 
-oechsler.it, www.oechsler.it {
+http://localhost:8080 {
+    encode zstd gzip
+
     root * /var/www/html
     try_files {path} {path}/ /index.html?{query}
     file_server


### PR DESCRIPTION
This change is due to the usage of a reverse-proxy in production